### PR TITLE
Adds a template ADO pipeline for deploying Marain infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,35 @@
 # Marain.Deployment
 
 This repository is used to help manage the deployments of your own [Marain](https://github.com/marain-dotnet/) instances.
+
+By default the pipeline models three environments:
+- marain_dev
+- marain_test
+- marain_prod
+
+>NOTE: Whilst Azure DevOps will automatically create the environments you will need to add manual approvals to, at least, all but the 'dev' environment.
+
+## Getting Started
+
+### Global Variables
+These variables are values that are intended to be the same across all environments - initially they are defined the following default values:
+
+|Name | Default | Description
+|-----|---------|------------
+|Marain_InstanceType | Stable | sets which release channel to use (valid options: Stable or Development)
+|Marain_ResourcePrefix | mar | the naming-convention prefix for all resources. If necessary, this can be overridden for a particular environment.
+
+
+
+
+### Environment-specific Variables
+Each environment requires the following variables to be set - initially they are defined with the following placeholder values:
+
+|Name | Default | Description
+|-----|---------|------------
+Marain_AzureLocation|<REPLACE_ME>| The Azure location for the deployment
+Marain_AzureSubscriptionId|<REPLACE_ME>| The subscription ID into which Marain should be deployed
+Marain_AzureTenantId|<REPLACE_ME>| The Azure tenant ID for the above subscription
+Marain_ServiceConnectionName|<REPLACE_ME>| The name of the Azure DevOps AzureRM service connection with permissions to the above subscription
+Marain_EnvironmentSuffix|<REPLACE_ME>| This will form the suffix of the naming convention used when creating resources (e.g. 'dev', 'test', 'prod')
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,128 @@
+# Azure DevOps pipeline for deploying the core infrastructure for https://github.com/marain-dotnet
+
+name: marain-dotnet_deployment
+
+resources:
+  repositories:
+  - repository: MarainInstanceGithub
+    type: github
+    name: marain-dotnet/Marain.Instance
+    ref: master
+
+trigger: none
+
+variables:
+  Marain_InstanceType: Stable     # sets which release channel to use (options: Stable or Development)
+  Marain_ResourcePrefix: mar      # the naming-convention prefix for all resources
+
+stages:
+- stage: Download deployment system
+  displayName: Build stage
+  jobs:
+  - job: pull_deploy_sources
+    displayName: Pull deployment sources
+    pool:
+      vmImage: 'ubuntu-latest'
+    steps:
+    - checkout: MarainInstanceGithub
+
+    - publish: $(Build.SourcesDirectory)/Solutions
+      artifact: marain_instance
+
+
+- stage: Deploy DEV Instance
+  variables:
+    Marain_AzureLocation: <REPLACE_ME>          # The Azure location for the deployment
+    Marain_AzureSubscriptionId: <REPLACE_ME>    # The subscription ID into which Marain should be deployed
+    Marain_AzureTenantId: <REPLACE_ME>          # The Azure tenant ID for the above subscription
+    Marain_ServiceConnectionName: <REPLACE_ME>  # The name of the Azure DevOps AzureRM service connection with permissions to the above subscription
+    Marain_EnvironmentSuffix: <REPLACE_ME>      # This will form the suffix of the naming convention used when creating resources (e.g. 'dev', 'test', 'prod')
+  displayName: Deploy to 'dev' environment stage
+  jobs:
+  - deployment: deploy_dev
+    displayName: Deploy 'dev' instance
+    pool:
+      vmImage: 'ubuntu-latest'
+    environment: marain_dev
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+          - download: current
+            artifact: marain_instance
+
+          - template: azurepipeline-templates/deploy-marain-instance.yml@MarainInstanceGithub
+            parameters:
+              azureServiceConnection: $(Marain_ServiceConnectionName)
+              azureSubscriptionId: $(Marain_AzureSubscriptionId)
+              azureTenantId: $(Marain_AzureTenantId)
+              azureLocation: $(Marain_AzureLocation)
+              marainEnvironmentSuffix: $(Marain_EnvironmentSuffix)
+              marainInstanceType: $(Marain_InstanceType)
+              marainResourcePrefix: $(Marain_ResourcePrefix)
+              workingDirectory: $(Pipeline.Workspace)/marain_instance/Marain.Instance.Deployment
+
+- stage: Deploy TEST Instance
+  variables:
+    Marain_AzureLocation: <REPLACE_ME>
+    Marain_AzureSubscriptionId: <REPLACE_ME>
+    Marain_AzureTenantId: <REPLACE_ME>
+    Marain_ServiceConnectionName: <REPLACE_ME>
+    Marain_EnvironmentSuffix: <REPLACE_ME>
+  displayName: Deploy to 'test' environment stage
+  jobs:  
+  - deployment: deploy_test
+    displayName: Deploy 'test' instance
+    pool:
+      vmImage: 'ubuntu-latest'
+    environment: marain_test
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+          - download: current
+            artifact: marain_instance
+
+          - template: azurepipeline-templates/deploy-marain-instance.yml@MarainInstanceGithub
+            parameters:
+              azureServiceConnection: $(Marain_ServiceConnectionName)
+              azureSubscriptionId: $(Marain_AzureSubscriptionId)
+              azureTenantId: $(Marain_AzureTenantId)
+              azureLocation: $(Marain_AzureLocation)
+              marainEnvironmentSuffix: $(Marain_EnvironmentSuffix)
+              marainInstanceType: $(Marain_InstanceType)
+              marainResourcePrefix: $(Marain_ResourcePrefix)
+              workingDirectory: $(Pipeline.Workspace)/marain_instance/Marain.Instance.Deployment
+
+- stage: Deploy PROD Instance
+  variables:
+    Marain_AzureLocation: <REPLACE_ME>
+    Marain_AzureSubscriptionId: <REPLACE_ME>
+    Marain_AzureTenantId: <REPLACE_ME>
+    Marain_ServiceConnectionName: <REPLACE_ME>
+    Marain_EnvironmentSuffix: <REPLACE_ME>
+  displayName: Deploy to 'prod' environment stage
+  jobs: 
+  - deployment: deploy_prod
+    displayName: Deploy 'prod' instance
+    pool:
+      vmImage: 'ubuntu-latest'
+    environment: marain_prod
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+          - download: current
+            artifact: marain_instance
+
+          - template: azurepipeline-templates/deploy-marain-instance.yml@MarainInstanceGithub
+            parameters:
+              azureServiceConnection: $(Marain_ServiceConnectionName)
+              azureSubscriptionId: $(Marain_AzureSubscriptionId)
+              azureTenantId: $(Marain_AzureTenantId)
+              azureLocation: $(Marain_AzureLocation)
+              marainEnvironmentSuffix: $(Marain_EnvironmentSuffix)
+              marainInstanceType: $(Marain_InstanceType)
+              marainResourcePrefix: $(Marain_ResourcePrefix)
+              workingDirectory: $(Pipeline.Workspace)/marain_instance/Marain.Instance.Deployment
+                              


### PR DESCRIPTION
This repo will act as a template that users can clone to simplify getting their Marain infrastructure deployed into their environment, whilst also allowing them to manage their own configuration in a way that is de-coupled from the core Marain repos.

The pipeline models an example 3 environment configuration and references the `Marain.Instance` repo for the core deployment tooling as well as an ADO step template.

